### PR TITLE
Allow hiding Python interpreter name in status bar

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,7 @@ Except from `test`, `debug` and `datascience` features of [vscode-python](https:
 - `python.autoComplete.showAdvancedMembers`:Controls appearance of methods with double underscores in the completion list., default: `true`
 - `python.autoComplete.typeshedPaths`:Specifies paths to local typeshed repository clone(s) for the Python language server., default: `[]`
 - `python.autoUpdateLanguageServer`:Automatically update the language server., default: `true`
+- `python.hideInterpreterName`:Hide Python interpreter name in status bar., default: `false`
 - `python.disableInstallationCheck`:Whether to check if Python is installed (also warn when using the macOS-installed Python)., default: `false`
 - `python.envFile`:Absolute path to a file containing environment variable definitions., default: `"${workspaceFolder}/.env"`
 - `python.trace.server`:Trace level of tsserver, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -181,6 +181,12 @@
           "description": "Automatically update the language server.",
           "scope": "application"
         },
+        "python.hideInterpreterName": {
+          "type": "boolean",
+          "default": false,
+          "description": "Hide interpreter name in status bar.",
+          "scope": "application"
+        },
         "python.disableInstallationCheck": {
           "type": "boolean",
           "default": false,

--- a/src/common/configSettings.ts
+++ b/src/common/configSettings.ts
@@ -43,6 +43,7 @@ export class PythonSettings implements IPythonSettings {
   public analysis!: IAnalysisSettings
   public autoUpdateLanguageServer = true
   public datascience!: IDataScienceSettings
+  public hideInterpreterName = false
 
   protected readonly changed = new Emitter<void>()
   private workspaceRoot: Uri
@@ -147,6 +148,7 @@ export class PythonSettings implements IPythonSettings {
     this.downloadLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('downloadLanguageServer', true))!
     this.jediEnabled = systemVariables.resolveAny(pythonSettings.get<boolean>('jediEnabled', true))!
     this.autoUpdateLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('autoUpdateLanguageServer', true))!
+    this.hideInterpreterName = systemVariables.resolveAny(pythonSettings.get<boolean>('hideInterpreterName', false))!
     if (this.jediEnabled) {
       // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
       this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -163,6 +163,7 @@ export interface IPythonSettings {
   readonly globalModuleInstallation: boolean
   readonly analysis: IAnalysisSettings
   readonly autoUpdateLanguageServer: boolean
+  readonly hideInterpreterName: boolean
   readonly datascience: IDataScienceSettings
   readonly onDidChange: Event<void>
 }


### PR DESCRIPTION
Adds a new option `python.hideInterpreterName` (`false` by default), which, if
set to `true`, will hide the selected Python interpreter name (something like
`Python 3.8.5 64-bit ('python-3.8.5': venv)`) in the status bar. If an
interpreter was not found, the text `No Python Interpreter` will still be
displayed regardless of the setting of `python.hideInterpreterName`.